### PR TITLE
feat: support all HTTP methods & handle errors gracefully

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,5 +13,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Restore the dependencies
         run: npm ci
-      - name: Build
+      - name: Build and Test
         run: npm run all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Get the sources
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v2
       - name: Restore the dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/get.yml
+++ b/.github/workflows/get.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo ${{ steps.query.outputs.status }}
         shell: bash
       - name: Print the response headers
-        run: echo ${{ steps.query.outputs.status }}
+        run: echo ${{ steps.query.outputs.headers }}
         shell: bash
       - name: Print the response payload
         run: echo ${{ steps.query.outputs.response }}

--- a/.github/workflows/get.yml
+++ b/.github/workflows/get.yml
@@ -16,9 +16,12 @@ jobs:
         uses: ./
         with:
           url: 'https://jsonplaceholder.typicode.com/todos?id=1'
-      - name: Print the query status
+      - name: Print the response status
         run: echo ${{ steps.query.outputs.status }}
         shell: bash
-      - name: Print the query result
+      - name: Print the response headers
+        run: echo ${{ steps.query.outputs.status }}
+        shell: bash
+      - name: Print the response payload
         run: echo ${{ steps.query.outputs.response }}
         shell: bash

--- a/.github/workflows/get.yml
+++ b/.github/workflows/get.yml
@@ -10,9 +10,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Get the sources
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v2
       - name: Execute a dummy query
         id: query
         uses: ./

--- a/.github/workflows/graphql.yml
+++ b/.github/workflows/graphql.yml
@@ -10,9 +10,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Get the sources
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v2
       - name: Execute a dummy query
         id: query
         uses: ./

--- a/.github/workflows/graphql.yml
+++ b/.github/workflows/graphql.yml
@@ -23,9 +23,12 @@ jobs:
                 emoji
               }
             }
-      - name: Print the query status
+      - name: Print the response status
         run: echo ${{ steps.query.outputs.status }}
         shell: bash
-      - name: Print the query result
+      - name: Print the response headers
+        run: echo ${{ steps.query.outputs.status }}
+        shell: bash
+      - name: Print the response payload
         run: echo ${{ steps.query.outputs.response }}
         shell: bash

--- a/.github/workflows/graphql.yml
+++ b/.github/workflows/graphql.yml
@@ -27,7 +27,7 @@ jobs:
         run: echo ${{ steps.query.outputs.status }}
         shell: bash
       - name: Print the response headers
-        run: echo ${{ steps.query.outputs.status }}
+        run: echo ${{ steps.query.outputs.headers }}
         shell: bash
       - name: Print the response payload
         run: echo ${{ steps.query.outputs.response }}

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -19,11 +19,11 @@ jobs:
           method: post
           data: '{ "title": "dummy-todo", "userId": 1, "completed": false }'
       - name: Print the response status
-        run: echo ${{ steps.query.outputs.status }}
+        run: echo ${{ steps.request.outputs.status }}
         shell: bash
       - name: Print the response headers
-        run: echo ${{ steps.query.outputs.status }}
+        run: echo ${{ steps.request.outputs.headers }}
         shell: bash
       - name: Print the response payload
-        run: echo ${{ steps.query.outputs.response }}
+        run: echo ${{ steps.request.outputs.response }}
         shell: bash

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -19,8 +19,12 @@ jobs:
           method: post
           data: '{ "title": "dummy-todo", "userId": 1, "completed": false }'
       - name: Print the response status
-        run: echo ${{ steps.request.outputs.status }}
+      - name: Print the response status
+        run: echo ${{ steps.query.outputs.status }}
         shell: bash
-      - name: Print the response
-        run: echo ${{ steps.request.outputs.response }}
+      - name: Print the response headers
+        run: echo ${{ steps.query.outputs.status }}
+        shell: bash
+      - name: Print the response payload
+        run: echo ${{ steps.query.outputs.response }}
         shell: bash

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -10,9 +10,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Get the sources
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v2
       - name: Execute a dummy request
         id: request
         uses: ./

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -19,7 +19,6 @@ jobs:
           method: post
           data: '{ "title": "dummy-todo", "userId": 1, "completed": false }'
       - name: Print the response status
-      - name: Print the response status
         run: echo ${{ steps.query.outputs.status }}
         shell: bash
       - name: Print the response headers

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Typescript Action that performs HTTP requests within your workflow. It support
 | Name | Description |
 | --- | --- |
 | `status` | Numeric response status code | 
+| `headers` | JSON encoded response HTTP headers |
 | `response` | JSON encoded response |
 
 ### Examples

--- a/__tests__/http.test.ts
+++ b/__tests__/http.test.ts
@@ -5,49 +5,47 @@ import {request} from '../src/http'
 jest.mock('axios')
 
 describe('when calling get', () => {
-  const fakeGet = axios.get as jest.MockedFunction<typeof axios.get>
+  const fakeRequest = axios.request as jest.MockedFunction<typeof axios.request>
 
   beforeEach(() => {
     jest.resetModules()
 
-    when(fakeGet)
-      .calledWith('url')
+    when(fakeRequest)
+      .calledWith(expect.anything())
       .mockReturnValue(Promise.resolve({status: 200, data: {some: 'JSON'}}))
   })
 
   it('should call axios with the appropriate url and payload', async () => {
     await request('url', 'get')
 
-    expect(fakeGet).toHaveBeenCalledWith('url', {
-      headers: {'Content-Type': 'application/json'},
-      responseType: 'json'
+    expect(fakeRequest).toHaveBeenCalledWith({
+      url: 'url',
+      method: 'get',
+      data: '{}',
+      headers: expect.anything()
     })
   })
 })
 
 describe('when calling post', () => {
-  const fakePost = axios.post as jest.MockedFunction<typeof axios.post>
+  const fakeRequest = axios.request as jest.MockedFunction<typeof axios.request>
 
   beforeEach(() => {
     jest.resetModules()
 
-    when(fakePost)
-      .calledWith('url', '{"a": "JSON"}')
+    when(fakeRequest)
+      .calledWith(expect.anything())
       .mockReturnValue(Promise.resolve({status: 200, data: {some: 'JSON'}}))
   })
 
   it('should call axios with the appropriate url and payload', async () => {
     await request('url', 'post', '{"a": "JSON"}')
 
-    expect(fakePost).toHaveBeenCalledWith('url', '{"a": "JSON"}', {
-      headers: {'Content-Type': 'application/json'},
-      responseType: 'json'
+    expect(fakeRequest).toHaveBeenCalledWith({
+      url: 'url',
+      method: 'post',
+      data: '{"a": "JSON"}',
+      headers: expect.anything()
     })
-  })
-})
-
-describe('when calling unimplemented method', () => {
-  it('should throw unimplemented error', async () => {
-    await expect(request('url', 'delete', '')).rejects.toThrow()
   })
 })

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -1,5 +1,7 @@
+import axios from 'axios'
 import * as core from '@actions/core'
 import {run} from '../src/main'
+import {when} from 'jest-when'
 
 jest.setTimeout(600000)
 
@@ -72,5 +74,55 @@ describe('when called with a GraphQL query', () => {
 
     expect(fakeSetOutput).toBeCalledWith('status', expect.anything())
     expect(fakeSetOutput).toBeCalledWith('response', expect.anything())
+  })
+})
+
+describe('when action fails', () => {
+  it('should handle missing input gracefully', async () => {
+    const fakeSetOutput = jest.spyOn(core, 'setOutput')
+
+    await run()
+
+    expect(fakeSetOutput).not.toHaveBeenCalled()
+  })
+
+  it('should handle invalid input errors gracefully ', async () => {
+    process.env['INPUT_URL'] = 'https://jsonplaceholder.typicode.com/todos?id=1'
+    process.env['INPUT_METHOD'] = 'invalid-http-method'
+
+    const fakeLogError = jest.spyOn(core, 'error')
+    const fakeSetOutput = jest.spyOn(core, 'setOutput')
+
+    // does not throw exception
+    await run()
+
+    // once for each of the following: status, headers, response and final error message
+    expect(fakeLogError).toHaveBeenCalledTimes(4)
+    expect(fakeSetOutput).not.toHaveBeenCalled()
+
+    delete process.env['INPUT_URL']
+    delete process.env['INPUT_METHOD']
+  })
+})
+
+describe('when HTTP request fails', () => {
+  jest.mock('axios')
+  const fakeRequest = axios.request as jest.MockedFunction<typeof axios.request>
+
+  beforeEach(() => {
+    process.env['INPUT_URL'] = 'https://jsonplaceholder.typicode.com/todos?id=1'
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    delete process.env['INPUT_URL']
+  })
+
+  it('should handle server-side errors gracefully ', async () => {
+    // TODO
+  })
+
+  it('should handle action-side errors gracefully ', async () => {
+    // TODO
   })
 })

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -103,26 +103,38 @@ describe('when action fails', () => {
     delete process.env['INPUT_URL']
     delete process.env['INPUT_METHOD']
   })
-})
-
-describe('when HTTP request fails', () => {
-  jest.mock('axios')
-  const fakeRequest = axios.request as jest.MockedFunction<typeof axios.request>
-
-  beforeEach(() => {
-    process.env['INPUT_URL'] = 'https://jsonplaceholder.typicode.com/todos?id=1'
-    jest.resetModules()
-  })
-
-  afterEach(() => {
-    delete process.env['INPUT_URL']
-  })
 
   it('should handle server-side errors gracefully ', async () => {
-    // TODO
+    // request will 404 because server does not respond to POST
+    process.env['INPUT_URL'] = 'https://camilogarcialarotta.io/'
+    process.env['INPUT_METHOD'] = 'post'
+
+    const fakeLogError = jest.spyOn(core, 'error')
+    const fakeSetOutput = jest.spyOn(core, 'setOutput')
+
+    // does not throw exception
+    await run()
+
+    // once for each of the following: status, headers, response and final error message
+    expect(fakeLogError).toHaveBeenCalledTimes(4)
+    expect(fakeSetOutput).not.toHaveBeenCalled()
+
+    delete process.env['INPUT_URL']
+    delete process.env['INPUT_METHOD']
   })
 
   it('should handle action-side errors gracefully ', async () => {
-    // TODO
+    // request won't be generated because it's an invalid protocol
+    process.env['INPUT_URL'] = 'ftp://>invalid|url<'
+
+    const fakeLogError = jest.spyOn(core, 'error')
+    const fakeSetOutput = jest.spyOn(core, 'setOutput')
+
+    // does not throw exception
+    await run()
+
+    // once for each of the following: status, headers, response and final error message
+    expect(fakeLogError).toHaveBeenCalledTimes(4)
+    expect(fakeSetOutput).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -96,8 +96,8 @@ describe('when action fails', () => {
     // does not throw exception
     await run()
 
-    // once for each of the following: status, headers, response and final error message
-    expect(fakeLogError).toHaveBeenCalledTimes(4)
+    // once for each of the following: status, headers, response
+    expect(fakeLogError).toHaveBeenCalledTimes(3)
     expect(fakeSetOutput).not.toHaveBeenCalled()
 
     delete process.env['INPUT_URL']
@@ -115,8 +115,8 @@ describe('when action fails', () => {
     // does not throw exception
     await run()
 
-    // once for each of the following: status, headers, response and final error message
-    expect(fakeLogError).toHaveBeenCalledTimes(4)
+    // once for each of the following: status, headers, response
+    expect(fakeLogError).toHaveBeenCalledTimes(3)
     expect(fakeSetOutput).not.toHaveBeenCalled()
 
     delete process.env['INPUT_URL']
@@ -133,8 +133,8 @@ describe('when action fails', () => {
     // does not throw exception
     await run()
 
-    // once for each of the following: status, headers, response and final error message
-    expect(fakeLogError).toHaveBeenCalledTimes(4)
+    // once for each of the following: status, headers, response
+    expect(fakeLogError).toHaveBeenCalledTimes(3)
     expect(fakeSetOutput).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -12,12 +12,8 @@ describe('when running the action with valid inputs', () => {
     jest.resetModules()
 
     when(fakeRequest)
-      .calledWith('url', 'GET')
-      .mockReturnValue(Promise.resolve([200, {some: 'JSON'}]))
-
-    when(fakeRequest)
-      .calledWith('url', 'POST', '{ a: "payload" }')
-      .mockReturnValue(Promise.resolve([200, {some: 'JSON'}]))
+      .calledWith('url', expect.anything())
+      .mockReturnValue(Promise.resolve([200, 'headers', {some: 'JSON'}]))
 
     process.env['INPUT_URL'] = 'url'
   })
@@ -39,6 +35,7 @@ describe('when running the action with valid inputs', () => {
       ['method: POST'],
       ['data: { a: "payload" }'],
       ['response status: 200'],
+      ['response headers: "headers"'],
       ['response body:\n{"some":"JSON"}']
     ])
 
@@ -54,6 +51,7 @@ describe('when running the action with valid inputs', () => {
     await run()
 
     expect(fakeSetOutput).toBeCalledWith('status', '200')
+    expect(fakeSetOutput).toBeCalledWith('headers', expect.anything())
     expect(fakeSetOutput).toBeCalledWith('response', '{"some":"JSON"}')
 
     delete process.env['INPUT_METHOD']

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,8 @@ inputs:
 outputs:
   status:
     description: The status of the HTTP request
+  headers:
+    description: The response HTTP headers
   response:
     description: The raw query response body
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -887,7 +887,6 @@ function run() {
             core.setOutput('response', `${response}`);
         }
         catch (error) {
-            core.error(error);
             core.setFailed(error.message);
         }
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -2728,18 +2728,12 @@ function request(url, method, data = '{}') {
                 const payload = error.response.data;
                 return [status, headers, payload];
             }
-            else if (error.request) {
-                // `error.request` is an instance of XMLHttpRequest
-                return [
-                    500,
-                    '',
-                    `request was made but no response was received: ${error.request}`
-                ];
-            }
-            else {
-                // Something happened in setting up the request that triggered an Error
-                return [500, '', `request could not be generated: ${error.message}`];
-            }
+            // Something happened in setting up the request that triggered an error
+            return [
+                500,
+                '',
+                `request could not be generated: ${JSON.stringify(error.message)}`
+            ];
         }
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -870,11 +870,20 @@ function run() {
             if (data.length !== 0) {
                 core.info(`data: ${data}`);
             }
-            const [status, rawResponse] = yield http_1.request(url, method, data);
+            const [status, rawHeaders, rawResponse] = yield http_1.request(url, method, data);
+            const headers = JSON.stringify(rawHeaders);
             const response = JSON.stringify(rawResponse);
+            if (status < 200 || status >= 300) {
+                core.error(`response status: ${status}`);
+                core.error(`response headers: ${headers}`);
+                core.error(`response body:\n${response}`);
+                throw new Error(`request failed: ${response}`);
+            }
             core.info(`response status: ${status}`);
+            core.info(`response headers: ${headers}`);
             core.info(`response body:\n${response}`);
             core.setOutput('status', `${status}`);
+            core.setOutput('headers', `${headers}`);
             core.setOutput('response', `${response}`);
         }
         catch (error) {
@@ -2699,39 +2708,42 @@ const axios_1 = __importDefault(__webpack_require__(53));
  */
 function request(url, method, data = '{}') {
     return __awaiter(this, void 0, void 0, function* () {
-        switch (method.toUpperCase()) {
-            case 'POST':
-                return post(url, data);
-            case 'GET':
-                return get(url);
-            default:
-                throw new Error(`unimplemented HTTP method: ${method}`);
+        try {
+            const response = yield axios_1.default.request({
+                url,
+                method,
+                data,
+                headers: { 'Content-Type': 'application/json' }
+            });
+            const status = response.status;
+            const headers = response.headers;
+            const payload = response.data;
+            return [status, headers, payload];
+        }
+        catch (error) {
+            if (error.response) {
+                // The request was made and the server responded with a status code
+                const status = error.response.status;
+                const headers = error.response.headers;
+                const payload = error.response.data;
+                return [status, headers, payload];
+            }
+            else if (error.request) {
+                // `error.request` is an instance of XMLHttpRequest
+                return [
+                    500,
+                    '',
+                    `request was made but no response was received: ${error.request}`
+                ];
+            }
+            else {
+                // Something happened in setting up the request that triggered an Error
+                return [500, '', `request could not be generated: ${error.message}`];
+            }
         }
     });
 }
 exports.request = request;
-function get(url) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const response = yield axios_1.default.get(url, {
-            responseType: 'json',
-            headers: { 'Content-Type': 'application/json' }
-        });
-        const status = response.status;
-        const data = response.data;
-        return [status, data];
-    });
-}
-function post(url, payload) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const response = yield axios_1.default.post(url, payload, {
-            responseType: 'json',
-            headers: { 'Content-Type': 'application/json' }
-        });
-        const status = response.status;
-        const data = response.data;
-        return [status, data];
-    });
-}
 
 
 /***/ }),

--- a/src/http.ts
+++ b/src/http.ts
@@ -34,17 +34,14 @@ export async function request(
       const payload = error.response.data as Object
 
       return [status, headers, payload]
-    } else if (error.request) {
-      // `error.request` is an instance of XMLHttpRequest
-      return [
-        500,
-        '',
-        `request was made but no response was received: ${error.request}`
-      ]
-    } else {
-      // Something happened in setting up the request that triggered an Error
-      return [500, '', `request could not be generated: ${error.message}`]
     }
+
+    // Something happened in setting up the request that triggered an error
+    return [
+      500,
+      '',
+      `request could not be generated: ${JSON.stringify(error.message)}`
+    ]
   }
 }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -12,40 +12,40 @@ export async function request(
   url: string,
   method: Method,
   data = '{}'
-): Promise<[number, Object]> {
-  switch (method.toUpperCase()) {
-    case 'POST':
-      return post(url, data)
-    case 'GET':
-      return get(url)
+): Promise<[number, Object, Object]> {
+  try {
+    const response = await axios.request({
+      url,
+      method,
+      data,
+      headers: {'Content-Type': 'application/json'}
+    })
 
-    default:
-      throw new Error(`unimplemented HTTP method: ${method}`)
+    const status = response.status
+    const headers = response.headers
+    const payload = response.data as Object
+
+    return [status, headers, payload]
+  } catch (error) {
+    if (error.response) {
+      // The request was made and the server responded with a status code
+      const status = error.response.status
+      const headers = error.response.headers
+      const payload = error.response.data as Object
+
+      return [status, headers, payload]
+    } else if (error.request) {
+      // `error.request` is an instance of XMLHttpRequest
+      return [
+        500,
+        '',
+        `request was made but no response was received: ${error.request}`
+      ]
+    } else {
+      // Something happened in setting up the request that triggered an Error
+      return [500, '', `request could not be generated: ${error.message}`]
+    }
   }
-}
-
-async function get(url: string): Promise<[number, Object]> {
-  const response = await axios.get(url, {
-    responseType: 'json',
-    headers: {'Content-Type': 'application/json'}
-  })
-
-  const status = response.status
-  const data = response.data as Object
-
-  return [status, data]
-}
-
-async function post(url: string, payload: string): Promise<[number, Object]> {
-  const response = await axios.post(url, payload, {
-    responseType: 'json',
-    headers: {'Content-Type': 'application/json'}
-  })
-
-  const status = response.status
-  const data = response.data as Object
-
-  return [status, data]
 }
 
 export type Method =

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,6 @@ export async function run(): Promise<void> {
     core.setOutput('headers', `${headers}`)
     core.setOutput('response', `${response}`)
   } catch (error) {
-    core.error(error)
     core.setFailed(error.message)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,14 +22,29 @@ export async function run(): Promise<void> {
       core.info(`data: ${data}`)
     }
 
-    const [status, rawResponse] = await request(url, <Method>method, data)
+    const [status, rawHeaders, rawResponse] = await request(
+      url,
+      <Method>method,
+      data
+    )
 
+    const headers = JSON.stringify(rawHeaders)
     const response = JSON.stringify(rawResponse)
 
+    if (status < 200 || status >= 300) {
+      core.error(`response status: ${status}`)
+      core.error(`response headers: ${headers}`)
+      core.error(`response body:\n${response}`)
+
+      throw new Error(`request failed: ${response}`)
+    }
+
     core.info(`response status: ${status}`)
+    core.info(`response headers: ${headers}`)
     core.info(`response body:\n${response}`)
 
     core.setOutput('status', `${status}`)
+    core.setOutput('headers', `${headers}`)
     core.setOutput('response', `${response}`)
   } catch (error) {
     core.error(error)


### PR DESCRIPTION
Closes https://github.com/CamiloGarciaLaRotta/watermelon-http-client/issues/5

### What
This PR does 3 things:
- allow requests of any valid HTTP type
- add a new output parameter: `headers`
- handle http request errors (server-side and client-side) gracefully

You can see the new error handling in the [CI checks](https://github.com/CamiloGarciaLaRotta/watermelon-http-client/runs/552786100#step:4:76)

