### PR TITLE
fix: 'kind-of' dependency vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4263,9 +4263,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "kleur": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@actions/core": "^1.2.0",
     "@types/jest-when": "^2.7.0",
     "axios": "^0.19.2",
-    "jest-when": "^2.7.0"
+    "jest-when": "^2.7.0",
+    "kind-of": ">=6.0.3"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",


### PR DESCRIPTION
👋🏽

Closes https://github.com/CamiloGarciaLaRotta/watermelon-http-client/issues/7

### What
One of our transitive dependencies, `kind-of` has a moderate vulnerability: https://github.com/advisories/GHSA-6c8f-qphg-qjgp

This PR bumps it to the patched version by explicitly defining it in `package.json`