### PR TITLE
chore: add dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,10 +3,9 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "live"
-    default_assignees:
-      - CamiloGarciaLaRotta
     default_reviewers:
       - CamiloGarciaLaRotta
+      - titoine54
     commit_message:
       prefix: "fix"
       prefix_development: "chore"
@@ -18,8 +17,7 @@ update_configs:
     update_schedule: "daily"
     default_reviewers:
       - CamiloGarciaLaRotta
-    default_assignees:
-      - CamiloGarciaLaRotta
+      - titoine54
     commit_message:
       prefix: "fix"
       prefix_development: "chore"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -20,7 +20,6 @@ update_configs:
       - titoine54
     commit_message:
       prefix: "fix"
-      prefix_development: "chore"
     default_labels:
       - "dependencies"
       - "security"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,28 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    default_assignees:
+      - CamiloGarciaLaRotta
+    default_reviewers:
+      - CamiloGarciaLaRotta
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+    default_labels:
+      - "dependencies"
+      - "security"
+  - package_manager: "github_actions"
+    directory: "/"
+    update_schedule: "daily"
+    default_reviewers:
+      - CamiloGarciaLaRotta
+    default_assignees:
+      - CamiloGarciaLaRotta
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+    default_labels:
+      - "dependencies"
+      - "security"


### PR DESCRIPTION
Closes #9 

### What
This PR adds the config file for https://dependabot.com/
It will open PRs automatically whenever there are security vulnerabilities or dependency bumps at the NPM and GitHub Actions level.