### PR TITLE
chore: e2e test for custom headers 

### DIFF
--- a/.github/workflows/graphql_2.yml
+++ b/.github/workflows/graphql_2.yml
@@ -1,0 +1,38 @@
+name: Test GitHub GraphQL API
+on: push
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+      - name: Get the sources
+        uses: actions/checkout@v2
+      - name: Execute a dummy query
+        id: query
+        uses: ./
+        with:
+          headers: '{"Authorization": "bearer ${{ secrets.TOKEN }}" }'
+          graphql: |
+            query {
+              repository(name: "watermelon-http-client", owner:"camilogarcialarotta"){
+                issues(first:1) {
+                  nodes{
+                    title
+                    state
+                  }
+                }
+              }
+            }
+      - name: Print the response status
+        run: echo ${{ steps.query.outputs.status }}
+        shell: bash
+      - name: Print the response headers
+        run: echo ${{ steps.query.outputs.headers }}
+        shell: bash
+      - name: Print the response payload
+        run: echo ${{ steps.query.outputs.response }}
+        shell: bash


### PR DESCRIPTION
👋🏽

### What
This PR adds the end-to-end test for the custom headers story:
1. query the GitHub GraphQL api
2. pass the PAT (Personal Access Token) to the request as a header
3. assert a successful response