### PR TITLE
refactor: URL input defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Typescript Action that performs HTTP requests within your workflow. It support
 
 | Argument | Description | Default |
 | --- | --- | --- |
-| url | Endpoint to query | https://api.github.com/graphql |
+| url | Endpoint to query | https://api.github.com. If `graphql` is set, then https://api.github.com/graphql |
 | method | HTTP method | `GET` |
 | headers | JSON encoded HTTP headers | Empty by default. If no headers are supplied, GraphQL queries will be sent with `{'Content-Type': 'application/json'}` |
 | data | JSON encoded HTTP request payload |  |

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -12,7 +12,7 @@ describe('when running the action with valid inputs', () => {
     jest.resetModules()
 
     when(fakeRequest)
-      .calledWith('url', expect.anything(), expect.anything(), {
+      .calledWith(expect.anything(), expect.anything(), expect.anything(), {
         some: 'input-headers'
       })
       .mockReturnValue(
@@ -39,7 +39,7 @@ describe('when running the action with valid inputs', () => {
     expect(infoMock.mock.calls).toEqual([
       ['graphql: { some { mutation } }'],
       ['variables: {"some": "variables"}'],
-      ['url: url'],
+      ['url: https://api.github.com/graphql'],
       ['method: POST'],
       ['headers: {"some":"input-headers"}'],
       [

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -19,7 +19,7 @@ describe('when running the action with valid inputs', () => {
         Promise.resolve([200, {some: 'response-headers'}, {some: 'JSON'}])
       )
 
-    process.env['INPUT_URL'] = 'url'
+    process.env['INPUT_URL'] = 'https://api.github.com'
   })
 
   afterEach(() => {
@@ -66,7 +66,7 @@ describe('when running the action with valid inputs', () => {
     await run()
 
     expect(infoMock.mock.calls).toEqual([
-      ['url: url'],
+      ['url: https://api.github.com'],
       ['method: GET'],
       ['headers: {"some":"input-headers"}'],
       ['response status: 200'],
@@ -93,7 +93,7 @@ describe('when running the action with valid inputs', () => {
     await run()
 
     expect(infoMock.mock.calls).toEqual([
-      ['url: url'],
+      ['url: https://api.github.com'],
       ['method: POST'],
       ['headers: {"some":"input-headers"}'],
       ['data: {"some": "data"}'],

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "Camilo Garcia La Rotta"
 inputs:
   url:
     description: Endpoint to query
-    default: "https://api.github.com/graphql"
+    default: "https://api.github.com"
   method:
     description: HTTP method
     default: get

--- a/dist/index.js
+++ b/dist/index.js
@@ -856,7 +856,7 @@ const graphql_1 = __webpack_require__(500);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const url = core.getInput('url');
+            let url = core.getInput('url');
             let method = core.getInput('method');
             const rawInputHeaders = core.getInput('headers');
             let data = core.getInput('data');
@@ -870,6 +870,9 @@ function run() {
                 inputHeaders = {};
             }
             if (graphql.length !== 0) {
+                if (!isCustomURL(url)) {
+                    url = 'https://api.github.com/graphql';
+                }
                 method = 'POST';
                 data = graphql_1.graphqlPayloadFor(graphql, variables);
                 if (isEmpty(inputHeaders)) {
@@ -907,6 +910,7 @@ function run() {
 }
 exports.run = run;
 const isEmpty = (o) => Object.keys(o).length === 0;
+const isCustomURL = (url) => url !== 'https://api.github.com';
 run();
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import {graphqlPayloadFor} from './graphql'
 
 export async function run(): Promise<void> {
   try {
-    const url: string = core.getInput('url')
+    let url: string = core.getInput('url')
     let method: string = core.getInput('method')
     const rawInputHeaders: string = core.getInput('headers')
     let data: string = core.getInput('data')
@@ -20,6 +20,10 @@ export async function run(): Promise<void> {
     }
 
     if (graphql.length !== 0) {
+      if (!isCustomURL(url)) {
+        url = 'https://api.github.com/graphql'
+      }
+
       method = 'POST'
       data = graphqlPayloadFor(graphql, variables)
 
@@ -69,5 +73,6 @@ export async function run(): Promise<void> {
 }
 
 const isEmpty = (o: Object): Boolean => Object.keys(o).length === 0
+const isCustomURL = (url: string): Boolean => url !== 'https://api.github.com'
 
 run()


### PR DESCRIPTION
👋🏽

Closes #37 

### What
This PR changes the default URL from `https://api.github.com/graphql` to `https://api.github.com`.
The idea is that we should implement sensible defaults:
- the most common requests are GET/POST, so we should default to the REST API by default
- if the user defines a GraphQL query/mutation, then we know they'll want the GraphQL API if no URL is defined