### PR TITLE
refactor: sensible URL defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Typescript Action that performs HTTP requests within your workflow. It support
 
 | Argument | Description | Default |
 | --- | --- | --- |
-| url | Endpoint to query | https://api.github.com/graphql |
+| url | Endpoint to query | https://api.github.com. If `graphql` is set, then https://api.github.com/graphql |
 | method | HTTP method | `GET` |
 | headers | JSON encoded HTTP headers | Empty by default. If no headers are supplied, GraphQL queries will be sent with `{'Content-Type': 'application/json'}` |
 | data | JSON encoded HTTP request payload |  |

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -116,7 +116,6 @@ describe('when action fails', () => {
     const errorMock = jest.spyOn(Logger.prototype, 'error')
     const outputMock = jest.spyOn(core, 'setOutput')
 
-    // does not throw exception
     await run()
 
     // once for each of the following: status, headers, response
@@ -135,7 +134,6 @@ describe('when action fails', () => {
     const errorMock = jest.spyOn(Logger.prototype, 'error')
     const outputMock = jest.spyOn(core, 'setOutput')
 
-    // does not throw exception
     await run()
 
     // once for each of the following: status, headers, response
@@ -147,13 +145,11 @@ describe('when action fails', () => {
   })
 
   it('should handle action-side errors gracefully ', async () => {
-    // request won't be generated because it's an invalid protocol
     process.env['INPUT_URL'] = 'ftp://>invalid|url<'
 
     const fakeLogError = jest.spyOn(core, 'error')
     const outputMock = jest.spyOn(core, 'setOutput')
 
-    // does not throw exception
     await run()
 
     // once for each of the following: status, headers, response

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "Camilo Garcia La Rotta"
 inputs:
   url:
     description: Endpoint to query
-    default: "https://api.github.com/graphql"
+    default: "https://api.github.com"
   method:
     description: HTTP method
     default: get

--- a/dist/index.js
+++ b/dist/index.js
@@ -880,12 +880,13 @@ const log_1 = __webpack_require__(732);
 const http_1 = __webpack_require__(617);
 const isEmpty = (o) => Object.keys(o).length === 0;
 const isDefined = (input) => input !== '{}' && input.length > 0;
+const isCustomURL = (url) => url !== 'https://api.github.com';
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const verbose = core_1.getInput('verbose') === 'true';
             const log = new log_1.Logger(verbose);
-            const url = core_1.getInput('url');
+            let url = core_1.getInput('url');
             let method = core_1.getInput('method');
             const rawInputHeaders = core_1.getInput('headers');
             let data = core_1.getInput('data');
@@ -900,6 +901,9 @@ function run() {
                 inputHeaders = {};
             }
             if (isDefined(graphql)) {
+                if (!isCustomURL(url)) {
+                    url = 'https://api.github.com/graphql';
+                }
                 method = 'POST';
                 data = graphql_1.graphqlPayloadFor(graphql, variables);
                 if (isEmpty(inputHeaders)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,13 +6,14 @@ import {request} from './http'
 
 const isEmpty = (o: Object): boolean => Object.keys(o).length === 0
 const isDefined = (input: string): boolean => input !== '{}' && input.length > 0
+const isCustomURL = (url: string): Boolean => url !== 'https://api.github.com'
 
 export async function run(): Promise<void> {
   try {
     const verbose: boolean = getInput('verbose') === 'true'
     const log = new Logger(verbose)
 
-    const url: string = getInput('url')
+    let url: string = getInput('url')
     let method: string = getInput('method')
     const rawInputHeaders: string = getInput('headers')
     let data: string = getInput('data')
@@ -29,6 +30,9 @@ export async function run(): Promise<void> {
     }
 
     if (isDefined(graphql)) {
+      if (!isCustomURL(url)) {
+        url = 'https://api.github.com/graphql'
+      }
       method = 'POST'
       data = graphqlPayloadFor(graphql, variables)
 


### PR DESCRIPTION
👋🏽

Closes #37 

### What
This PR changes the default URL from `https://api.github.com/graphql` to `https://api.github.com`.
The idea is that we should implement sensible defaults:
- the most common requests are GET/POST, so we should default to the REST API by default
- if the user defines a GraphQL query/mutation, then we know they'll want the GraphQL API if no URL is defined