### PR TITLE
feat: support 'operationName'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Typescript Action that performs HTTP requests within your workflow. It support
 | data | JSON encoded HTTP request payload |  |
 | graphql | GraphQL query/mutation to execute | Empty by default. If defined, the `data` field is automatically populated with this payload and the `method` is set to `POST` |
 | variables | JSON encoded variables for the GraphQL mutation | |
+| operation_name | name of the entrypoint GraphQL operation if multiple are defined in `graphql` | |
 | verbose | wether to print info-level statements or not | false |
 
 ## Outputs

--- a/__tests__/graphql.test.ts
+++ b/__tests__/graphql.test.ts
@@ -28,4 +28,18 @@ describe('calling graphqlPayloadFor', () => {
       '{"query":"foo { data }","variables":{}}'
     )
   })
+
+  it('should set operationName if passed', () => {
+    const queries = `query A {
+      foo {
+        bar
+      }
+    }
+    query B {
+      baz
+    }`
+    expect(graphqlPayloadFor(queries, '{}', 'A')).toMatch(
+      '{"query":"query A { foo { bar } } query B { baz }","variables":{},"operationName":"A"}'
+    )
+  })
 })

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
   variables:
     description: variables for a GraphQL mutation in JSON format
     default: '{}'
+  operation_name:
+    description: name of the entrypoint GraphQL operation if multiple are defined in `graphql`
   verbose:
     description: wether to print info-level statements or not
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -847,12 +847,17 @@ const minify = (s) => s.replace(/\s+/g, ' ').trim();
  *
  * @param {string} rawQuery - The stringified GraphQL query or mutation.
  * @param {string} rawVariables - The JSON mutation variables.
+ * @param {string} operationName - The entrypoint GraphQL operation if multiple are defined in `rawQuery`.
  * @returns {string} `{"query": <GraphQL query>, "variables": <variables>}`.
  */
-function graphqlPayloadFor(rawQuery, rawVariables) {
+function graphqlPayloadFor(rawQuery, rawVariables, operationName = '') {
     const query = minify(rawQuery);
-    const variables = minify(rawVariables);
-    return JSON.stringify({ query, variables: JSON.parse(variables) });
+    const minifiedVariables = minify(rawVariables);
+    const variables = JSON.parse(minifiedVariables);
+    if (operationName === '') {
+        return JSON.stringify({ query, variables });
+    }
+    return JSON.stringify({ query, variables, operationName });
 }
 exports.graphqlPayloadFor = graphqlPayloadFor;
 
@@ -901,7 +906,7 @@ function run() {
             }
             if (isDefined(graphql)) {
                 method = 'POST';
-                data = graphql_1.graphqlPayloadFor(graphql, variables);
+                data = graphql_1.graphqlPayloadFor(graphql, variables, operationName);
                 if (isEmpty(inputHeaders)) {
                     inputHeaders = { 'Content-Type': 'application/json' };
                 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -12,13 +12,21 @@ const minify = (s: string): string => s.replace(/\s+/g, ' ').trim()
  *
  * @param {string} rawQuery - The stringified GraphQL query or mutation.
  * @param {string} rawVariables - The JSON mutation variables.
+ * @param {string} operationName - The entrypoint GraphQL operation if multiple are defined in `rawQuery`.
  * @returns {string} `{"query": <GraphQL query>, "variables": <variables>}`.
  */
 export function graphqlPayloadFor(
   rawQuery: string,
-  rawVariables: string
+  rawVariables: string,
+  operationName = ''
 ): string {
   const query = minify(rawQuery)
-  const variables = minify(rawVariables)
-  return JSON.stringify({query, variables: JSON.parse(variables)})
+  const minifiedVariables = minify(rawVariables)
+  const variables = JSON.parse(minifiedVariables)
+
+  if (operationName === '') {
+    return JSON.stringify({query, variables})
+  }
+
+  return JSON.stringify({query, variables, operationName})
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ export async function run(): Promise<void> {
 
     if (isDefined(graphql)) {
       method = 'POST'
-      data = graphqlPayloadFor(graphql, variables)
+      data = graphqlPayloadFor(graphql, variables, operationName)
 
       if (isEmpty(inputHeaders)) {
         inputHeaders = {'Content-Type': 'application/json'}


### PR DESCRIPTION
👋🏽

Closes #40 

### What
This PR adds support for `operationName` as defined in the GraphQL spec
https://graphql.org/learn/serving-over-http/#post-request