### PR TITLE
Update documentation to include content type with headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ url: 'https://countries.trevorblades.com/'
 ```yaml
 uses: CamiloGarciaLaRotta/watermelon-http-client@v1
 with:
-  headers: '{"Authorization": "bearer ${{ secrets.TOKEN }}" }'
+  headers: '{"Authorization": "bearer ${{ secrets.TOKEN }}", "Content-Type": "application/json" }'
   graphql: |
     mutation addRocketEmoji($reaction:AddReactionInput!) {
       addReaction(input:$reaction) {


### PR DESCRIPTION
When defining the Authorization header, content type is not set. Add Content type to the example.

@camilogarcialarotta

### What
I believe the code is working as intended, but this might help other who end up in this situation. https://github.com/CamiloGarciaLaRotta/watermelon-http-client/issues/157
